### PR TITLE
Fix nesting of cron-job file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ env:
     - SEGFAULT_SIGNALS=all
 
 addons:
-  apt:
-    sources:
-      - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-      - shellcheck
 
 matrix:
   include:

--- a/Templates/make_jira-dc_EC2-node.tmplt.json
+++ b/Templates/make_jira-dc_EC2-node.tmplt.json
@@ -422,8 +422,7 @@
                     ]
                   ]
                 }
-              }
-            },
+              },
               "/etc/cron.d/jira-data-backup": {
                 "content": {
                   "Fn::Join": [
@@ -452,6 +451,7 @@
                 "group": "root",
                 "mode": "000700",
                 "owner": "root"
+              }
             }
           },
           "configSets": {


### PR DESCRIPTION
Ensures that, not only is the cron file defined, its placement-task is executed